### PR TITLE
feat: switch to using the /oauth2 provider

### DIFF
--- a/server.js
+++ b/server.js
@@ -42,9 +42,9 @@ console.log(`\nAuthenticating...\n`);
 
 let tenantURL = process.env.TENANT_URL;
 if(tenantURL.endsWith('/')) {
-  tenantURL = `${tenantURL}oidc/endpoint/default/.well-known/openid-configuration`
+  tenantURL = `${tenantURL}oauth2/.well-known/openid-configuration`
 } else {
-  tenantURL = `${tenantURL}/oidc/endpoint/default/.well-known/openid-configuration`
+  tenantURL = `${tenantURL}/oauth2/.well-known/openid-configuration`
 }
 
 Issuer.discover(tenantURL)


### PR DESCRIPTION
Verify supports two OIDC providers. This change modifies the example to use the new endpoints.

NOTE: Applications created using the custom connector template will work with both endpoints. /oauth2 offers addtional capabilities that are visible in the OpenID Connect application connector.